### PR TITLE
imports changed for React Native .4 and above syntax

### DIFF
--- a/react-native-linea/RCTLinea.h
+++ b/react-native-linea/RCTLinea.h
@@ -6,8 +6,8 @@
 //  Copyright © 2016 Angelo. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
-#import "RCTEventEmitter.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #import "DTDevices.h"
 
 @interface RCTLinea : RCTEventEmitter <RCTBridgeModule, DTDeviceDelegate> {

--- a/react-native-linea/RCTLinea.m
+++ b/react-native-linea/RCTLinea.m
@@ -7,9 +7,9 @@
 //
 
 #import "RCTLinea.h"
-#import "RCTBridgeModule.h"
-#import "RCTEventDispatcher.h"
-#import "RCTEventEmitter.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTEventEmitter.h>
 
 @implementation RCTLinea
 


### PR DESCRIPTION
Imports syntax changed per this document for upgrade to RN v.4 and above: https://github.com/facebook/react-native/releases/tag/v0.40.0